### PR TITLE
feat: Don't use deprecated AutoDoc() features

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -1,8 +1,9 @@
 LoadPackage("AutoDoc");
 
-AutoDoc("smallantimagmas" : scaffold := true,
-                             extract_examples := true,
-                             autodoc := rec(scan_dirs := ["lib"])
-);
+AutoDoc(rec(
+    scaffold := true,
+    extract_examples := true,
+    autodoc := rec(scan_dirs := ["lib"])
+));
 
 QUIT;


### PR DESCRIPTION
- don't pass package name
- don't use global GAP options, use an options record

These have been deprecated for many years and may be removed
in a future AutoDoc release.
