### PR TITLE
feat: Make the test suite work without the SmallGrp package

### DIFF
--- a/lib/properties.gd
+++ b/lib/properties.gd
@@ -3,7 +3,7 @@
 #! identifies whether magma <A>M</A> is antiassociative.
 #!
 #! @BeginExampleSession
-#! gap> IsAntiassociative(OneSmallGroup(16));
+#! gap> IsAntiassociative(CyclicGroup(16));
 #! false
 #! gap> IsAntiassociative(OneSmallAntimagma(2));
 #! true
@@ -22,11 +22,11 @@ DeclareProperty("IsAntiassociative", IsMagma);
 #! <magma with 2 generators>
 #! gap> AssociativityIndex(OneSmallAntimagma(2));
 #! 0
-#! gap> OneSmallGroup(4);
+#! gap> CyclicGroup(4);
 #! <pc group of size 4 with 2 generators>
-#! gap> AssociativityIndex(OneSmallGroup(4));
+#! gap> AssociativityIndex(CyclicGroup(4));
 #! 64
-#! gap> AssociativityIndex(OneSmallGroup(4)) = 4 ^ 3;
+#! gap> AssociativityIndex(CyclicGroup(4)) = 4 ^ 3;
 #! true
 #! @EndExampleSession
 #!
@@ -98,7 +98,7 @@ DeclareGlobalFunction("AllSubmagmas");
 #! identifies class of antiassociative magma <A>M</A>.
 #!
 #! @BeginExampleSession
-#! gap> IsAntiassociative(OneSmallGroup(16));
+#! gap> IsAntiassociative(CyclicGroup(16));
 #! false
 #! gap> IsAntiassociative(OneSmallAntimagma(2));
 #! true

--- a/tst/test_properties_element_left_right_order.tst
+++ b/tst/test_properties_element_left_right_order.tst
@@ -1,10 +1,12 @@
 gap> START_TEST("test_properties_element_left_right_order.tst");
 
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> ForAll(AllSmallGroups([2 .. 10]), G -> ForAll(Elements(G), g -> Order(g) = LeftOrder(g)));
 true
 
 gap> ForAll(AllSmallGroups([2 .. 10]), G -> ForAll(Elements(G), g -> Order(g) = RightOrder(g)));
 true
+#@fi
 
 gap> ForAll(AllSmallAntimagmas([2 .. 3]), M -> ForAll(Filtered(Elements(M), m -> LeftOrder(m) <> infinity), m -> LeftOrder(m) <> RightOrder(m)));
 true

--- a/tst/test_properties_magma_associativity_index.tst
+++ b/tst/test_properties_magma_associativity_index.tst
@@ -1,7 +1,9 @@
 gap> START_TEST("test_properties_magma_associativity_index.tst");
 
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> ForAll(AllSmallGroups([2 .. 12]), M -> AssociativityIndex(M) = Size(M) ^ 3);
 true
+#@fi
 
 gap>  ForAll(AllSmallAntimagmas([2 .. 3]), M -> AssociativityIndex(M) = 0);
 true

--- a/tst/test_properties_magma_left_right_cancellative.tst
+++ b/tst/test_properties_magma_left_right_cancellative.tst
@@ -1,5 +1,6 @@
 gap> START_TEST("test_properties_magma_left_right_cancellative.tst");
 
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> ForAll(AllSmallGroups([2 .. 4]), G -> IsLeftCancellative(G));
 true
 
@@ -8,6 +9,7 @@ true
 
 gap> ForAll(AllSmallGroups([2 .. 4]), G -> IsCancellative(G));
 true
+#@fi
 
 gap> ForAny(AllSmallAntimagmas([2 .. 3]), M -> IsCancellative(M));
 false

--- a/tst/test_properties_magma_left_right_cylic.tst
+++ b/tst/test_properties_magma_left_right_cylic.tst
@@ -1,5 +1,6 @@
 gap> START_TEST("test_properties_magma_left_right_cyclic.tst");
 
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> ForAll(Filtered(AllSmallGroups([2 .. 12]), G -> not IsCyclic(G)), G -> not IsLeftCyclic(G));
 true
 
@@ -11,5 +12,6 @@ true
 
 gap> ForAll(Filtered(AllSmallGroups([2 .. 12]), G -> IsCyclic(G)), G -> IsRightCyclic(G));        
 true
+#@fi
 
 gap> STOP_TEST("test_properties_magma_left_right_cyclic.tst");


### PR DESCRIPTION
The tests used the small groups library in two different ways, and
without SmallGrp both failed with

    Error, Variable: 'AllSmallGroups' must have a value

resp. for OneSmallGroup.

The manual examples in lib/properties.gd used OneSmallGroup(16) and
OneSmallGroup(4), which are just the cyclic groups of those orders, so
use CyclicGroup instead. This gives the same view string, the same
IsAntiassociative and the same AssociativityIndex.

The four tests iterating over AllSmallGroups genuinely enumerate the
small groups library, checking a property for all groups of order up to
10 resp. 12, and have no such replacement; guard them using the `#@if'
syntax of the test file parser. The neighbouring checks on antimagmas
keep running in either case.

See https://github.com/gap-system/gap/issues/2434

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
